### PR TITLE
eliminate bind from documentStringToModel

### DIFF
--- a/lib/runtime/facade.js
+++ b/lib/runtime/facade.js
@@ -71,7 +71,7 @@ function documentToModel(doc,cb,context){
 module.exports = {
     pathToModel : pathToModel,
     urlToModel : urlToModel,
-    documentStringToModel : documentStringToModel.bind(this,null),
+    documentStringToModel : documentStringToModel,
     documentToModel : documentToModel,
     ext : {
         platformModule : pm


### PR DESCRIPTION
appears to be a static function and has no dependency on the requiring module and fails when the caller provides uri,content,callback params because the null arg in the bind call shifts the parameters to the right by one.

 24 function documentStringToModel(url,docString,cb,context){
 25     debugger;
 26     var scJson = scxmlToScjson(docString);
 27 
debug> repl
Press Ctrl + C to leave debug repl
> url
null
> docString
'http://127.0.0.1/~matto/scxml/test/scxml/flat1.scxml'
